### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트

### DIFF
--- a/board-service/.gitignore
+++ b/board-service/.gitignore
@@ -1,6 +1,9 @@
 # Created by https://www.toptal.com/developers/gitignore/api/java,intellij+all,macos,gradle
 # Edit at https://www.toptal.com/developers/gitignore?templates=java,intellij+all,macos,gradle
 
+### Querydsl
+/src/main/generated
+
 ### Intellij+all ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/board-service/build.gradle
+++ b/board-service/build.gradle
@@ -25,9 +25,17 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    // Data Rest
+
     implementation 'org.springframework.boot:spring-boot-starter-data-rest'
     implementation 'org.springframework.data:spring-data-rest-hal-explorer'
+
+    // queryDSL 설정
+    implementation "com.querydsl:querydsl-jpa"
+    implementation "com.querydsl:querydsl-core"
+    implementation "com.querydsl:querydsl-collections"
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa" // querydsl JPAAnnotationProcessor 사용 지정
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api" // java.lang.NoClassDefFoundError (javax.annotation.Generated) 대응 코드
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api" // java.lang.NoClassDefFoundError (javax.annotation.Entity) 대응 코드
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -39,4 +47,22 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
 }

--- a/board-service/build.gradle
+++ b/board-service/build.gradle
@@ -25,6 +25,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // Data Rest
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'

--- a/board-service/src/main/java/me/gnoyes/boardservice/repository/ArticleCommentRepository.java
+++ b/board-service/src/main/java/me/gnoyes/boardservice/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package me.gnoyes.boardservice.repository;
 
 import me.gnoyes.boardservice.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/board-service/src/main/java/me/gnoyes/boardservice/repository/ArticleCommentRepository.java
+++ b/board-service/src/main/java/me/gnoyes/boardservice/repository/ArticleCommentRepository.java
@@ -1,9 +1,30 @@
 package me.gnoyes.boardservice.repository;
 
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.StringExpression;
 import me.gnoyes.boardservice.domain.ArticleComment;
+import me.gnoyes.boardservice.domain.QArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
-public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
+public interface ArticleCommentRepository extends
+        JpaRepository<ArticleComment, Long>,
+        QuerydslPredicateExecutor<ArticleComment>,
+        QuerydslBinderCustomizer<QArticleComment>
+{
+
+    @Override
+    default void customize(QuerydslBindings bindings, QArticleComment root) {
+        // ArticleComment의 모든 필드에 대해서 검색 기능이 열려있어서, 모두 닫아준다.
+        bindings.excludeUnlistedProperties(true);
+        // 필요한 검색 기능만 열어준다.
+        bindings.including(root.content, root.createdAt, root.createdBy);
+        bindings.bind(root.content).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.createdAt).first(DateTimeExpression::eq);
+        bindings.bind(root.createdBy).first(StringExpression::containsIgnoreCase);
+    }
 }

--- a/board-service/src/main/java/me/gnoyes/boardservice/repository/ArticleRepository.java
+++ b/board-service/src/main/java/me/gnoyes/boardservice/repository/ArticleRepository.java
@@ -1,9 +1,32 @@
 package me.gnoyes.boardservice.repository;
 
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.StringExpression;
 import me.gnoyes.boardservice.domain.Article;
+import me.gnoyes.boardservice.domain.QArticle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
-public interface ArticleRepository extends JpaRepository<Article, Long> {
+public interface ArticleRepository extends
+        JpaRepository<Article, Long>,
+        QuerydslPredicateExecutor<Article>,
+        QuerydslBinderCustomizer<QArticle>
+{
+
+    @Override
+    default void customize(QuerydslBindings bindings, QArticle root) {
+        // Article의 모든 필드에 대해서 검색 기능이 열려있어서, 모두 닫아준다.
+        bindings.excludeUnlistedProperties(true);
+        // 필요한 검색 기능만 열어준다.
+        bindings.including(root.title, root.content, root.hashtag, root.createdAt, root.createdBy);
+        bindings.bind(root.title).first(StringExpression::containsIgnoreCase); // like '%{value]%
+        bindings.bind(root.content).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.hashtag).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.createdAt).first(DateTimeExpression::eq);
+        bindings.bind(root.createdBy).first(StringExpression::containsIgnoreCase);
+    }
 }

--- a/board-service/src/main/java/me/gnoyes/boardservice/repository/ArticleRepository.java
+++ b/board-service/src/main/java/me/gnoyes/boardservice/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package me.gnoyes.boardservice.repository;
 
 import me.gnoyes.boardservice.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/board-service/src/main/resources/application.yml
+++ b/board-service/src/main/resources/application.yml
@@ -27,4 +27,6 @@ spring:
       hibernate.default_batch_fetch_size: 100
   h2.console.enabled: false
   sql.init.mode: always # resources/data.sql ? ?? ????
-
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated

--- a/board-service/src/test/java/me/gnoyes/boardservice/controller/DataRestTest.java
+++ b/board-service/src/test/java/me/gnoyes/boardservice/controller/DataRestTest.java
@@ -1,0 +1,85 @@
+package me.gnoyes.boardservice.controller;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Disabled("Spring Data REST 통합테스트는 불필요하므로 제외시킴")
+@DisplayName("Data REST가 API를 잘 생성했는지 테스트한다")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+class DataRestTest {
+
+    private final MockMvc mvc;
+
+    DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+
+    @DisplayName("게시글 리스트가 조회된다")
+    @Test
+    void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("게시글 단건 조회가 된다")
+    @Test
+    void givenNothing_whenRequestingArticle_thenReturnsArticleJsonResponse() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("게시글의 댓글 리스트를 조회한다")
+    @Test
+    void givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("댓글 리스트를 조회한다")
+    @Test
+    void givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("댓글 단건 조회를 한다")
+    @Test
+    void givenNothing_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+        // given
+
+        // when & then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 기본적인 CRUD 이므로 간단하게 Spring Data REST를 적용시켜보았다.
테스트는 해당 CRUD API 가 존재하는지, 정상 동작하는지만 확인하였다.